### PR TITLE
v1.0.10 - Cycle Release - OneClickZipSetup_v1.0.10_Release

### DIFF
--- a/App.config
+++ b/App.config
@@ -17,7 +17,7 @@
                 <value>0</value>
             </setting>
             <setting name="app_version_patch" serializeAs="String">
-                <value>9</value>
+                <value>10</value>
             </setting>
             <setting name="app_version_revision" serializeAs="String">
                 <value>0</value>

--- a/Includes/Classes/ZipArchiving.cs
+++ b/Includes/Classes/ZipArchiving.cs
@@ -105,6 +105,7 @@ namespace OneClickZip.Includes.Classes
             {
                 if (streeNodeEx.IsFolderIsFilterRule)
                 {
+                    generateSerializableTreeNode.SerializableTreeNodeObj = new SerializableTreeNode();
                     generateSerializableTreeNode.FolderFilterRuleObj = (FolderFilterRule)streeNodeEx.FolderFilterRuleObj.Clone();
                     generateSerializableTreeNode.StartGeneration();
                     SerializableTreeViewOperation.SerializeTreeNodeShallowCopy(

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.9.0")]
-[assembly: AssemblyFileVersion("1.0.9.0")]
+[assembly: AssemblyVersion("1.0.10.0")]
+[assembly: AssemblyFileVersion("1.0.10.0")]

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -43,7 +43,7 @@ namespace OneClickZip.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("9")]
+        [global::System.Configuration.DefaultSettingValueAttribute("10")]
         public string app_version_patch {
             get {
                 return ((string)(this["app_version_patch"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -9,7 +9,7 @@
       <Value Profile="(Default)">0</Value>
     </Setting>
     <Setting Name="app_version_patch" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">9</Value>
+      <Value Profile="(Default)">10</Value>
     </Setting>
     <Setting Name="app_version_revision" Type="System.String" Scope="Application">
       <Value Profile="(Default)">0</Value>

--- a/Setup/One_Click_Zip_Inno_Setup_Packaging.iss
+++ b/Setup/One_Click_Zip_Inno_Setup_Packaging.iss
@@ -4,7 +4,7 @@
 #define MyAppName "One Click Zip"
 #define MyAppNameForRegistry "One_Click_Zip_Designer"
 #define MyAppNameForRegistryBatch "One_Click_Zip_Designer_Batch"
-#define MyAppVersion "1.0.9.0"
+#define MyAppVersion "1.0.10.0"
 #define MyAppPublisher "AngelsSoftwareOrg"
 #define MyAppURL "https://github.com/" + MyAppPublisher + "/"
 #define MyAppExeName "OneClickZip.exe"
@@ -24,7 +24,7 @@
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
-AppId={{C527D9E0-4448-4F17-93A9-177C0E26464F}
+AppId={{09C4FCCE-CBDC-4719-967B-E8B07ED2E71B}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 ;AppVerName={#MyAppName} {#MyAppVersion}


### PR DESCRIPTION
Test for v1.0.10.0
- Fix the compilation of files from Dynamic Filter Rule to not mix within another filter rule output folders
- Set up new app version